### PR TITLE
📝docs: rename chainabstractionlayer to chainify

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Query different blockchains with account management using a single and simple in
 
 ## Dependencies
 
-This repository was built as an extension to the [ChainAbstractionLayer](https://github.com/liquality/chainabstractionlayer) maintained by the core contributors of [Liquality](https://liquality.io). It is necessary to include the `Client` and `providers` from the `@liquality` npm packages in order to use providers such as the `BitcoinDlcProvider`.
+This repository was built as an extension to the [Chainify](https://github.com/liquality/chainify) maintained by the core contributors of [Liquality](https://liquality.io). It is necessary to include the `Client` and `providers` from the `@liquality` npm packages in order to use providers such as the `BitcoinDlcProvider`.
 
 ## Chain Support
 
@@ -20,13 +20,13 @@ This repository was built as an extension to the [ChainAbstractionLayer](https:/
 
 |Package|Version|
 |---|---|
-|[@atomicfinance/bitcoin-cfd-provider](./packages/bitcoin-cfd-provider)|[![ChainAbstractionLayer-Finance](https://img.shields.io/npm/v/@atomicfinance/bitcoin-cfd-provider.svg)](https://npmjs.com/package/@atomicfinance/bitcoin-cfd-provider)|
-|[@atomicfinance/bitcoin-dlc-provider](./packages/bitcoin-dlc-provider)|[![ChainAbstractionLayer-Finance](https://img.shields.io/npm/v/@atomicfinance/bitcoin-dlc-provider.svg)](https://npmjs.com/package/@atomicfinance/bitcoin-dlc-provider)|
-|[@atomicfinance/bitcoin-wallet-provider](./packages/bitcoin-wallet-provider)|[![ChainAbstractionLayer-Finance](https://img.shields.io/npm/v/@atomicfinance/bitcoin-wallet-provider.svg)](https://npmjs.com/package/@atomicfinance/bitcoin-wallet-provider)|
-|[@atomicfinance/bitcoin-networks](./packages/bitcoin-networks)|[![ChainAbstractionLayer-Finance](https://img.shields.io/npm/v/@atomicfinance/bitcoin-networks.svg)](https://npmjs.com/package/@atomicfinance/bitcoin-networks)|
-|[@atomicfinance/client](./packages/client)|[![ChainAbstractionLayer-Finance](https://img.shields.io/npm/v/@atomicfinance/client.svg)](https://npmjs.com/package/@atomicfinance/client)|
-|[@atomicfinance/provider](./packages/provider)|[![ChainAbstractionLayer-Finance](https://img.shields.io/npm/v/@atomicfinance/provider.svg)](https://npmjs.com/package/@atomicfinance/provider)
-|[@atomicfinance/types](./packages/types)|[![ChainAbstractionLayer-Finance](https://img.shields.io/npm/v/@atomicfinance/types.svg)](https://npmjs.com/package/@atomicfinance/types)
+|[@atomicfinance/bitcoin-cfd-provider](./packages/bitcoin-cfd-provider)|[![Chainify-Finance](https://img.shields.io/npm/v/@atomicfinance/bitcoin-cfd-provider.svg)](https://npmjs.com/package/@atomicfinance/bitcoin-cfd-provider)|
+|[@atomicfinance/bitcoin-dlc-provider](./packages/bitcoin-dlc-provider)|[![Chainify-Finance](https://img.shields.io/npm/v/@atomicfinance/bitcoin-dlc-provider.svg)](https://npmjs.com/package/@atomicfinance/bitcoin-dlc-provider)|
+|[@atomicfinance/bitcoin-wallet-provider](./packages/bitcoin-wallet-provider)|[![Chainify-Finance](https://img.shields.io/npm/v/@atomicfinance/bitcoin-wallet-provider.svg)](https://npmjs.com/package/@atomicfinance/bitcoin-wallet-provider)|
+|[@atomicfinance/bitcoin-networks](./packages/bitcoin-networks)|[![Chainify-Finance](https://img.shields.io/npm/v/@atomicfinance/bitcoin-networks.svg)](https://npmjs.com/package/@atomicfinance/bitcoin-networks)|
+|[@atomicfinance/client](./packages/client)|[![Chainify-Finance](https://img.shields.io/npm/v/@atomicfinance/client.svg)](https://npmjs.com/package/@atomicfinance/client)|
+|[@atomicfinance/provider](./packages/provider)|[![Chainify-Finance](https://img.shields.io/npm/v/@atomicfinance/provider.svg)](https://npmjs.com/package/@atomicfinance/provider)
+|[@atomicfinance/types](./packages/types)|[![Chainify-Finance](https://img.shields.io/npm/v/@atomicfinance/types.svg)](https://npmjs.com/package/@atomicfinance/types)
 
 ## DLC Spec Compliance
 

--- a/packages/provider/lib/Provider.ts
+++ b/packages/provider/lib/Provider.ts
@@ -4,7 +4,7 @@ export default abstract class Provider {
   client: IFinanceClient;
   /**
    * Set client to a provider instance.
-   * @param {!ChainAbstractionLayer} client - The ChainAbstractionLayer instance
+   * @param {!Chainify} client - The Chainify instance
    */
   setClient(client?: any) {
     this.client = client;

--- a/packages/types/lib/models/Input.ts
+++ b/packages/types/lib/models/Input.ts
@@ -4,18 +4,18 @@ import Amount from './Amount';
 import Utxo from './Utxo';
 
 /**
- * Class for interfacing with inputs/utxos in Liquality ChainAbstractionLayer
- * https://github.com/liquality/chainabstractionlayer
+ * Class for interfacing with inputs/utxos in Liquality Chainify
+ * https://github.com/liquality/chainify
  *
  * These inputs can have different fields for value
- * satoshis (sats): https://github.com/liquality/chainabstractionlayer/blob/dev/packages/bitcoin-esplora-api-provider/lib/BitcoinEsploraApiProvider.js#L65
- * amount (btc): https://github.com/liquality/chainabstractionlayer/blob/dev/packages/bitcoin-esplora-api-provider/lib/BitcoinEsploraApiProvider.js#L74
- * value (sats): https://github.com/liquality/chainabstractionlayer/blob/dev/packages/bitcoin-wallet-provider/lib/BitcoinWalletProvider.js#L331
+ * satoshis (sats): https://github.com/liquality/chainify/blob/dev/packages/bitcoin-esplora-api-provider/lib/BitcoinEsploraApiProvider.js#L65
+ * amount (btc): https://github.com/liquality/chainify/blob/dev/packages/bitcoin-esplora-api-provider/lib/BitcoinEsploraApiProvider.js#L74
+ * value (sats): https://github.com/liquality/chainify/blob/dev/packages/bitcoin-wallet-provider/lib/BitcoinWalletProvider.js#L331
  *
  * This will be fixed once typescript branch is merged:
- * https://github.com/liquality/chainabstractionlayer/tree/typescript
+ * https://github.com/liquality/chainify/tree/typescript
  * satoshis and amount will not be necessary, only value
- * https://github.com/liquality/chainabstractionlayer/blob/typescript/packages/types/lib/bitcoin.ts#L46
+ * https://github.com/liquality/chainify/blob/typescript/packages/types/lib/bitcoin.ts#L46
  */
 export default class Input {
   constructor(

--- a/tests/integration/common.ts
+++ b/tests/integration/common.ts
@@ -110,7 +110,7 @@ bitcoinWithJs3.addProvider(new BitcoinWalletProvider(network));
  * bitcoinWithJs4 corresponds to counterparty of dlc offer, accept, sign and txs messages in fixtures
  *
  * It was added to test the specific case where derivation path is > 500
- * Relevant issue: https://github.com/AtomicFinance/chainabstractionlayer-finance/issues/109
+ * Relevant issue: https://github.com/AtomicFinance/chainify-finance/issues/109
  */
 const bitcoinWithJs4 = new FinanceClient();
 bitcoinWithJs4.addProvider(mockedBitcoinRpcProvider());

--- a/tests/integration/dlc/dlc.test.ts
+++ b/tests/integration/dlc/dlc.test.ts
@@ -597,7 +597,7 @@ describe('dlc provider', () => {
     /**
      * Currently quickFindAddress only checked the first 5000 addresses
      * This means DlcSign would fail if any addresses are > 5000
-     * Relevant Issue: https://github.com/AtomicFinance/chainabstractionlayer-finance/issues/109
+     * Relevant Issue: https://github.com/AtomicFinance/chainify-finance/issues/109
      *
      * This test ensures this issue is accounted for when finalizingDlcSign
      */


### PR DESCRIPTION
## What

Rename `chainabstractionlayer` to `chainify`

## Why

[liquality/chainabstractionlayer](https://github.com/liquality/chainabstractionlayer) was recently renamed to [liquality/chainify](https://github.com/liquality/chainify)

Since this library builds on top of [liquality/chainabstractionlayer](https://github.com/liquality/chainabstractionlayer), it made sense to rename this library to chainify-finance